### PR TITLE
Removed unnecessary return statement

### DIFF
--- a/comint-intercept.el
+++ b/comint-intercept.el
@@ -194,8 +194,7 @@ The input string will be fed to the action function."
 		   for (pat . action) in comint-intercept-pattern-actions
 		   when (string-match pat str)
 		   do (progn
-			(funcall action str)
-			(return t)))))))))
+			(funcall action str)))))))))
     (funcall comint-intercept--origin-sender proc
 	     (if not-origin "" str))))
 


### PR DESCRIPTION
Invoking return isn't necessary to exit the provided action.
The return statement causes comint-intercept-pattern-actions to not work, removing it fixes the issue.